### PR TITLE
Place class in lambda

### DIFF
--- a/src/test/scala/matthelm/LeaderBoardTest.scala
+++ b/src/test/scala/matthelm/LeaderBoardTest.scala
@@ -9,24 +9,24 @@ import org.joda.time.{Duration, Instant}
 
 class LeaderBoardTest extends PipelineSpec {
 
-  case class GameActionInfo(user: String, team: String, score: Int, timestamp: Long)
-
-  case class TestUser(user: String, team: String)
-
-  private def event(user: TestUser,
-                    score: Int,
-                    baseTimeOffset: Duration): TimestampedValue[GameActionInfo] = {
-    val t = (new Instant(0)).plus(baseTimeOffset)
-    TimestampedValue.of(GameActionInfo(user.user, user.team, score, t.getMillis), t)
-  }
-
   "LeaderBoard.calculateTeamScores" should "work with on time elements" in {
+    case class GameActionInfo(user: String, team: String, score: Int, timestamp: Long)
+
+    case class TestUser(user: String, team: String)
+
     val baseTime = new Instant(0)
 
     val redOne = TestUser("scarlet", "red")
     val redTwo = TestUser("burgundy", "red")
     val blueOne = TestUser("navy", "blue")
     val blueTwo = TestUser("sky", "blue")
+
+    def event(user: TestUser,
+                      score: Int,
+                      baseTimeOffset: Duration): TimestampedValue[GameActionInfo] = {
+      val t = (new Instant(0)).plus(baseTimeOffset)
+      TimestampedValue.of(GameActionInfo(user.user, user.team, score, t.getMillis), t)
+    }
 
     val stream = testStreamOf[GameActionInfo]
       .advanceWatermarkTo(baseTime)


### PR DESCRIPTION
This PR follows #1 and moves the `case class` defs and function into the test lambda. 

![image](https://user-images.githubusercontent.com/819476/57160451-acecbd80-6d9d-11e9-9aaa-2a6ea903cbab.png)

The issue remains with the same error...

```
➜  scio-leader-board-test git:(place-class-in-lambda) sbt test                             
[info] Loading global plugins from /Users/matthelm/.sbt/1.0/plugins
[info] Loading settings for project scio-leader-board-test-build from plugins.sbt ...
[info] Loading project definition from /Users/matthelm/scio-leader-board-test/project
[info] Loading settings for project root from build.sbt ...
[info] Set current project to scio-leader-board-test (in build file:/Users/matthelm/scio-leader-board-test/)
[info] LeaderBoardTest:
[info] LeaderBoard.calculateTeamScores
[info] - should work with on time elements *** FAILED ***
[info]   java.lang.IllegalArgumentException: unable to serialize RecordCoder[matthelm.LeaderBoardTest.<local LeaderBoardTest>.GameActionInfo](user -> StringUtf8Coder, team -> StringUtf8Coder, score -> VarIntCoder, timestamp -> BigEndianLongCoder)
[info]   at org.apache.beam.sdk.util.SerializableUtils.serializeToByteArray(SerializableUtils.java:55)
[info]   at org.apache.beam.repackaged.beam_runners_direct_java.runners.core.construction.CoderTranslation.toCustomCoder(CoderTranslation.java:119)
[info]   at org.apache.beam.repackaged.beam_runners_direct_java.runners.core.construction.CoderTranslation.toProto(CoderTranslation.java:83)
[info]   at org.apache.beam.repackaged.beam_runners_direct_java.runners.core.construction.SdkComponents.registerCoder(SdkComponents.java:250)
[info]   at org.apache.beam.repackaged.beam_runners_direct_java.runners.core.construction.PCollectionTranslation.toProto(PCollectionTranslation.java:35)
[info]   at org.apache.beam.repackaged.beam_runners_direct_java.runners.core.construction.SdkComponents.registerPCollection(SdkComponents.java:205)
[info]   at org.apache.beam.repackaged.beam_runners_direct_java.runners.core.construction.PTransformTranslation.translateAppliedPTransform(PTransformTranslation.java:380)
[info]   at org.apache.beam.repackaged.beam_runners_direct_java.runners.core.construction.PTransformTranslation$KnownTransformPayloadTranslator.translate(PTransformTranslation.java:331)
[info]   at org.apache.beam.repackaged.beam_runners_direct_java.runners.core.construction.PTransformTranslation.toProto(PTransformTranslation.java:149)
[info]   at org.apache.beam.repackaged.beam_runners_direct_java.runners.core.construction.PTransformTranslation.toProto(PTransformTranslation.java:162)
[info]   ...
[info]   Cause: java.io.NotSerializableException: org.scalatest.Assertions$AssertionsHelper
[info]   at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
[info]   at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
[info]   at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
[info]   at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
[info]   at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
[info]   at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
[info]   at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
[info]   at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
[info]   at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
[info]   at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
[info]   ...
[info] WordCountTest:
[info] WordCount
[info] - should work
[info] ScalaTest
[info] Run completed in 5 seconds, 411 milliseconds.
[info] Total number of tests run: 2
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 1, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed: Total 2, Failed 1, Errors 0, Passed 1
[error] Failed tests:
[error]         matthelm.LeaderBoardTest
[error] (Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 9 s, completed 3-May-2019 12:19:55 PM
```